### PR TITLE
Upstream kippo project has moved to github

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
 FROM ubuntu:trusty
 MAINTAINER Thomas Léveil <thomasleveil@gmail.com>
 
-ADD build/ /tmp/build/
+COPY build/ /tmp/build/
 
 RUN bash /tmp/build/setup-apt-mirrors.sh
 RUN apt-get update
-RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install python-dev openssl python-openssl python-pyasn1 python-twisted subversion
+RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install python-dev openssl python-openssl python-pyasn1 python-twisted git
 
 RUN useradd -d /kippo -s /bin/bash -m kippo -g sudo
-RUN svn checkout http://kippo.googlecode.com/svn/trunk/ /kippo
-RUN mv /kippo/kippo.cfg.dist /kippo/kippo.cfg
-RUN chown kippo /kippo -R
+RUN git clone -q --depth 1 https://github.com/desaster/kippo.git /kippo-app
+RUN mv /kippo-app/kippo.cfg.dist /kippo-app/kippo.cfg
+RUN chown kippo /kippo-app -R
 
 
 # Clean up when done.
@@ -19,5 +19,5 @@ RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 EXPOSE 2222
 USER kippo
-WORKDIR /kippo
+WORKDIR /kippo-app
 CMD ["twistd", "--nodaemon", "-y", "kippo.tac", "--pidfile=kippo.pid"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,6 @@
 FROM ubuntu:trusty
 MAINTAINER Thomas Léveil <thomasleveil@gmail.com>
 
-COPY build/ /tmp/build/
-
-RUN bash /tmp/build/setup-apt-mirrors.sh
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get -q -y install python-dev openssl python-openssl python-pyasn1 python-twisted git
 
@@ -14,7 +11,6 @@ RUN chown kippo /kippo-app -R
 
 
 # Clean up when done.
-RUN rm -r /tmp/build/
 RUN apt-get clean && rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 EXPOSE 2222

--- a/README.md
+++ b/README.md
@@ -1,43 +1,37 @@
-docker-kippo
-============
-
-Dockerfile building an image with kippo ready to go
-
-Kippo will listen on port 2222
+# docker-kippo
 
 
+Dockerfile building an image with [kippo](https://github.com/desaster/kippo) ssh honeypot ready to go
 
-	
-Running
--------
+By Default, Kippo will listen on port 2222
 
+# Running
+
+```bash
     docker run -d -p 2222:2222 tomdesinto/kippo
+```
+## with make
 
-
-
-### with make
-
+```bash
     make run
-	
+```
+
 The container will map port 2222. Change this in the `Makefile`.
 
 Use `docker logs` to read kippo log
-	
-	
-	
-	
-Building
---------
 
-    git clone https://github.com/thomasleveil/docker-kippo.git
+## Building
+
+```bash
+  git clone https://github.com/thomasleveil/docker-kippo.git
 	cd docker-kippo
 	make build
-	
-	
-	
-Other
------
+```
 
+# Other
+
+```bash
     make shell
-	
+```
+
 Will run the container and present you with a shell.

--- a/build/setup-apt-mirrors.sh
+++ b/build/setup-apt-mirrors.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt trusty main restricted universe multiverse' /etc/apt/sources.list
-sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt trusty-updates main restricted universe multiverse' /etc/apt/sources.list
-sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt trusty-backports main restricted universe multiverse' /etc/apt/sources.list
-sed -i '1ideb mirror://mirrors.ubuntu.com/mirrors.txt trusty-security main restricted universe multiverse' /etc/apt/sources.list


### PR DESCRIPTION
This PR switches to using the (official) github based kippo

Also some minor README.md cleanup
